### PR TITLE
pypeeringmanager always returns `Record` object instead of instance of Model.

### DIFF
--- a/src/pypeeringmanager/core/app.py
+++ b/src/pypeeringmanager/core/app.py
@@ -14,3 +14,6 @@ class App(PyNetboxApp):
         "net": net,
         "extras": extras,
     }
+
+    def _setmodel(self):
+        self.model = self.__class__.models[self.name] if self.name in self.__class__.models else None


### PR DESCRIPTION
This fixes that pypeeringmanager always returned a pynetbox.core.response.Record instead of the given model.

The issue is that pynetbox.core.app calls `_set_model` and that method uses a hardcoded reference to pynetbox.core.App instead of giving the possibility to subclass app and provide your own models as pypeeringmanager is doing. This commit fixes that.