### PR TITLE
pkg_resources is deprecated as an API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pypeeringmanager
-version = 1.1.1
+version = 1.1.2
 author = vista
 author_email = vista@birb.network
 description = Peering-Manager API client library

--- a/src/pypeeringmanager/__init__.py
+++ b/src/pypeeringmanager/__init__.py
@@ -1,9 +1,13 @@
-from pkg_resources import get_distribution, DistributionNotFound
-
 from pynetbox.core.query import RequestError, AllocationError, ContentError
 from pypeeringmanager.core.api import Api as api
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # For Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"
+


### PR DESCRIPTION
Hey @vista- I'm currently getting this error:

```
/home/avermeer/Documents/network-automation/.venv/lib/python3.13/site-packages/pypeeringmanager/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
Traceback (most recent call last):
  File "/home/avermeer/Documents/network-automation/inventories/peering-manager.py", line 1, in <module>
    from pypeeringmanager import PeeringManager
ImportError: cannot import name 'PeeringManager' from 'pypeeringmanager' (/home/avermeer/Documents/network-automation/.venv/lib/python3.13/site-packages/pypeeringmanager/__init__.py)
```