### PR TITLE
Set strict_filters on Api for pynetbox compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pypeeringmanager
-version = 1.1.3
+version = 1.3.0
 author = vista
 author_email = vista@birb.network
 description = Peering-Manager API client library

--- a/src/pypeeringmanager/core/api.py
+++ b/src/pypeeringmanager/core/api.py
@@ -21,6 +21,8 @@ class Api(PyNetboxApi):
     :param str token: Your Peering-Manager token.
     :param bool,optional threading: Set to True to use threading in ``.all()``
         and ``.filter()`` requests.
+    :param bool,optional strict_filters: Mirror of pynetbox's option, read by
+        ``Endpoint.filter()``/``.get()``. Defaults to False (as in NetBox's API).
     :raises AttributeError: If app doesn't exist.
     :Examples:
     >>> import pypeeringmanager
@@ -32,7 +34,7 @@ class Api(PyNetboxApi):
     """
 
     def __init__(
-        self, url, token=None, threading=False,
+        self, url, token=None, threading=False, strict_filters=False,
     ):
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
@@ -41,6 +43,10 @@ class Api(PyNetboxApi):
         self.base_url = base_url
         self.session_key = None
         self.http_session = requests.Session()
+        # pynetbox's Endpoint.filter()/.get() read api.strict_filters; this
+        # __init__ overrides pynetbox's without calling super(), so set it here
+        # to stay compatible with current pynetbox releases.
+        self.strict_filters = strict_filters
         if threading and sys.version_info.major == 2:
             raise NotImplementedError(
                 "Threaded pypeeringmanager calls not supported in Python 2"


### PR DESCRIPTION
## Problem

`Api.__init__` overrides pynetbox's `Api.__init__` without calling `super()`, so the `strict_filters` attribute that pynetbox introduced is never set on the instance. Current pynetbox releases read `api.strict_filters` inside `Endpoint.filter()` / `Endpoint.get()`, so any filter or get call against a Peering Manager instance raises:

```
AttributeError: 'Api' object has no attribute 'strict_filters'
```

`.all()` happens to work, but `.filter(...)` and `.get(name=...)` do not, which makes server-side filtering unusable with up-to-date pynetbox.

## Fix

Accept a `strict_filters` argument (default `False`, matching NetBox's own API behaviour) and assign `self.strict_filters`, mirroring pynetbox's `Api` signature. Minimal and backwards-compatible — existing callers are unaffected.

## Version

Bumps `setup.cfg` to `1.3.0` (minor: backwards-compatible new parameter, over the latest released `1.2.0` tag). Drop this commit if you'd prefer to handle versioning/release separately.

## Test

```python
import pypeeringmanager
pm = pypeeringmanager.api("https://<pm-host>", token="...")
pm.devices.routers.get(name="some-router")   # raised AttributeError before, works now
```